### PR TITLE
Change the used token for the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:
-          CR_TOKEN: "${{ secrets.ACCESS_TOKEN }}"
+          CR_TOKEN: "${{ github.token }}"


### PR DESCRIPTION
---
name: Pull request
about: Contribute your changes to the project
title: '[pull-request]'
labels: ''
assignees: ''
---
**Description**
The current token in the release job for github actions caused me as user. 
I think for this we just need to use this now: "${{ github.token }}"

I have added the change to the releas.yml file. 

For any question contact me.

